### PR TITLE
Make date more portable

### DIFF
--- a/tinystatus
+++ b/tinystatus
@@ -108,7 +108,7 @@ for file in "${tmp}/ok/"*.status; do
 done
 cat << EOF
 </ul>
-<p class=small> Last check: $(date -I'seconds')</p>
+<p class=small> Last check: $(date +%FT%T%z)</p>
 EOF
 if [ -f "${incidentsfile}" ]; then
     echo '<h1>Incidents</h1>'


### PR DESCRIPTION
First off, what a simple and useful script!

The `date` builtin on macOS (tested on macOS 11.4 and 10.13.6) does not support the `-I `(`--iso-8601`) option.  Updated the call to `date` to use an output format that matches ISO 8601 with seconds as the timespec.

There are other solutions, but this keeps the output the same across platforms.