### PR TITLE
Support reporting errors on stderr

### DIFF
--- a/tinystatus
+++ b/tinystatus
@@ -7,6 +7,7 @@ tmp="$(mktemp -d)"
 checkfile="${1:-checks.csv}"
 incidentsfile="${2:-incidents.txt}"
 failonoutage=false
+reportonoutage=false
 useragent="User-Agent: Mozilla/5.0 (X11; Linux x86_64; Debian) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.88 Safari/537.36"
 
 command_exists(){
@@ -101,6 +102,9 @@ for file in "${tmp}/ko/"*.status; do
     name="$(basename "${file}" | sed 's,.status$,,')"
     status="$(cat "${file}")"
     echo "<li>${name} <span class='small failed'>(${status})</span><span class='status failed'>Disrupted</span></li>"
+    if [ "${reportonoutage}" = true ]; then
+        echo "${name} (${status})" >&2
+    fi
 done
 for file in "${tmp}/ok/"*.status; do
     [ -e "${file}" ] || continue


### PR DESCRIPTION
Hello, 

This change allows to report errors on stderr. It only adds 4 lines and it's behind a flag `reportonoutage` so that it doesn't change the default behavior.

This is useful when running tinystatus with cron as you can just add a `MAILTO` tag to receive alerts by mail without additional setup.  

Thank you for this little script! It's really nice and makes my life simpler!