### PR TITLE
Add simple OS-based dark/light mode

### DIFF
--- a/tinystatus
+++ b/tinystatus
@@ -77,6 +77,7 @@ OUTAGES_COUNT="$(ls "${TMP_DIR}/"*.ko | wc -l)"
 # Generate HTML
 cat << EOF
 <!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"><title>${TITLE}</title><style>
+:root { color-scheme: light dark; }
 body { font-family: segoe ui,Roboto,Oxygen-Sans,Ubuntu,Cantarell,helvetica neue,Verdana,sans-serif; }
 h1 { margin-top: 30px; }
 ul { padding: 0px; }


### PR DESCRIPTION
This is a bare-bones implementation of light/dark mode that relies on the operating system light/dark theme.

You can try it out here: https://up.liminal.cafe