### PR TITLE
Adds ability to include some details on status page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,5 +42,5 @@ There are also `http4`, `http6`, `ping4`, `ping6`, `port4`, `port6` for IPv4 or 
 Note: `port4` and `port6` require OpenBSD `nc` binary.
 
 ### Revision History
-v0.2.0 - Adds ability to include details with a variable `INCLUDE_DETAILS`; `ping` command will include trip time in ms in details portion.
-v0.1.0 - Assumed original version
+* v0.2.0 - Adds ability to include details with a variable `INCLUDE_DETAILS`; `ping` command will include trip time in ms in details portion.
+* v0.1.0 - Assumed original version

--- a/README.md
+++ b/README.md
@@ -35,9 +35,12 @@ Command, Expected Code, Status Text, Host to check
 
 Command can be:
 * `http` - Check http status
-* `ping` - Check ping status 
+* `ping` - Check ping status; its line on the status page will include the average time for the pings
 * `port` - Check open port status
 
 There are also `http4`, `http6`, `ping4`, `ping6`, `port4`, `port6` for IPv4 or IPv6 only check.  
 Note: `port4` and `port6` require OpenBSD `nc` binary.
 
+### Revision History
+v0.2.0 - Adds ability to include details with a variable `INCLUDE_DETAILS`; `ping` command will include trip time in ms in details portion.
+v0.1.0 - Assumed original version

--- a/tinystatus
+++ b/tinystatus
@@ -2,6 +2,7 @@
 
 # Configuration variables
 TITLE="Tinystatus"
+VERSION="0.2.0"
 HEADER="Global Status"
 CHECKS_FILE="${1:-checks.csv}"
 INCIDENTS_FILE="${2:-incidents.txt}"
@@ -27,6 +28,7 @@ check(){
     name="${3}"
     expected_rc="${4}"
     id="${5}"
+    details=""
 
     ipversion="$(echo "${check}" | grep -o '[46]$')"
     case "${check}" in
@@ -38,8 +40,9 @@ check(){
                 echo "Status code: ${rc}, expected: ${expected_rc}" > "${TMP_DIR}/${id}.ko.info"
             fi;;
         ping*)
-            ping -${ipversion}W "${TIMEOUT}" -c 1 "${host}" >/dev/null 2>&1
+            out=$(ping -${ipversion}W "${TIMEOUT}" -c 1 "${host}" 2>&1)
             rc=$?
+            details=$(echo ${out} | tail -1 | awk -F'/' '{print $5 " ms"}')
             [ "${rc}" -ne "${expected_rc}" ] && echo 'Host unreachable' > "${TMP_DIR}/${id}.ko.info";;
         port*)
             error="$(nc -${ipversion}w "${TIMEOUT}" -zv ${host} 2>&1)"
@@ -47,9 +50,9 @@ check(){
             [ "${rc}" -ne "${expected_rc}" ] && echo "${error}" | sed -e 's,nc: ,,' > "${TMP_DIR}/${id}.ko.info";;
     esac
 
-    # verity status and write files
     if [ "${rc}" -eq "${expected_rc}" ]; then
         echo "${name}" > "${TMP_DIR}/${id}.ok"
+        echo "${details}" >> "${TMP_DIR}/${id}.ok"
     else
         echo "${name}" > "${TMP_DIR}/${id}.ko"
     fi
@@ -104,17 +107,25 @@ cat << EOF
 <h1>Services</h1>
 <ul>
 EOF
+
 for file in "${TMP_DIR}/"*.ko; do
     [ -e "${file}" ] || continue
     echo "<li>$(cat "${file}") <span class='small failed'>($(cat "${file}.info"))</span><span class='status failed'>Disrupted</span></li>"
 done
 for file in "${TMP_DIR}/"*.ok; do
     [ -e "${file}" ] || continue
-    echo "<li>$(cat "${file}") <span class='status success'>Operational</span></li>"
+    name=$(head -1 ${file})
+    details=$(tail -1 ${file})
+    if [[ -n "$details" ]]; then
+      echo "<li>${name} <span class='status success'>Operational (${details})</span></li>"
+    else
+      echo "<li>${name} <span class='status success'>Operational</span></li>"
+    fi
 done
+
 cat << EOF
 </ul>
-<p class=small> Last check: $(date +%FT%T%z)</p>
+<p class=small>tinystatus v${VERSION} Last check: $(date +%FT%T%z)</p>
 EOF
 if [ -f "${INCIDENTS_FILE}" ]; then
     echo '<h1>Incidents</h1>'

--- a/tinystatus
+++ b/tinystatus
@@ -10,6 +10,7 @@ OUTAGE_RC=false
 TIMEOUT=10
 USER_AGENT="User-Agent: Mozilla/5.0 (X11; Linux x86_64; Debian) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.88 Safari/537.36"
 TMP_DIR="$(mktemp -d)"
+INCLUDE_DETAILS=1
 
 command_exists(){
     if ! command -v "${1}" >/dev/null 2>&1; then
@@ -115,11 +116,16 @@ done
 for file in "${TMP_DIR}/"*.ok; do
     [ -e "${file}" ] || continue
     name=$(head -1 ${file})
+    # If details contains something and its not empty, let's just wrap it in parentheses
     details=$(tail -1 ${file})
     if [[ -n "$details" ]]; then
-      echo "<li>${name} <span class='status success'>Operational (${details})</span></li>"
+        details="(${details})"
+    fi
+    # And if we are told to INCLUDE_DETAILS let's include it.
+    if (( INCLUDE_DETAILS )); then
+        echo "<li>${name} <span class='status success'>Operational ${details}</span></li>"
     else
-      echo "<li>${name} <span class='status success'>Operational</span></li>"
+        echo "<li>${name} <span class='status success'>Operational</span></li>"
     fi
 done
 


### PR DESCRIPTION
Basic ping trip time in MS is reported on the details page in the span for that commands results.  Turn on or off with setting script variable `INCLUDE_DETAILS=0`